### PR TITLE
Provide command line argument to inform KUBECONFIG path to use.

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -403,7 +403,7 @@ func (c *Controller) syncHandler(key string) error {
 		configlabel := watcher.WatcherLabel{}
 		configlabel.NameSpace = customConfigmap.Namespace
 		configlabel.ConfigMap = customConfigmap.Spec.ConfigMapName
-		go watcher.StartWatcher(configlabel, cm.Name, "")
+		go watcher.StartWatcher(c.kubeclientset, configlabel, cm.Name, "")
 		//store label in file
 		arrConfiglabel := watcher.Watcher{}
 		arrConfiglabel.Labels = append(arrConfiglabel.Labels, configlabel)
@@ -445,7 +445,7 @@ func (c *Controller) syncHandler(key string) error {
 			configlabel := watcher.WatcherLabel{}
 			configlabel.NameSpace = customConfigmap.Namespace
 			configlabel.ConfigMap = customConfigmap.Spec.ConfigMapName
-			go watcher.StartWatcher(configlabel, configMap.Name, cm.Name)
+			go watcher.StartWatcher(c.kubeclientset, configlabel, configMap.Name, cm.Name)
 			//store label in file
 			arrConfiglabel := watcher.Watcher{}
 			arrConfiglabel.Labels = append(arrConfiglabel.Labels, configlabel)

--- a/controller/secretcontroller.go
+++ b/controller/secretcontroller.go
@@ -72,7 +72,7 @@ func (c *Controller) secretSyncHandler(key string) error {
 		secretlabel := watcher.WatcherLabel{}
 		secretlabel.NameSpace = customSecret.Namespace
 		secretlabel.Secret = customSecret.Spec.SecretName
-		go watcher.StartWatcher(secretlabel, s.Name, "")
+		go watcher.StartWatcher(c.kubeclientset, secretlabel, s.Name, "")
 		//store label in file
 		arrSecretlabel := watcher.Watcher{}
 		arrSecretlabel.Labels = append(arrSecretlabel.Labels, secretlabel)
@@ -138,7 +138,7 @@ func (c *Controller) secretSyncHandler(key string) error {
 			secretlabel := watcher.WatcherLabel{}
 			secretlabel.NameSpace = customSecret.Namespace
 			secretlabel.Secret = customSecret.Spec.SecretName
-			go watcher.StartWatcher(secretlabel, secret.Name, s.Name)
+			go watcher.StartWatcher(c.kubeclientset, secretlabel, secret.Name, s.Name)
 			//store label in file
 			arrSecretlabel := watcher.Watcher{}
 			arrSecretlabel.Labels = append(arrSecretlabel.Labels, secretlabel)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"time"
 
@@ -15,32 +16,46 @@ import (
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"k8s.io/klog"
 )
 
 func main() {
 
-	cfg, err := rest.InClusterConfig()
+	var kubeconfig *string
+	var cfg *rest.Config
+	var err error
+
+	kubeconfig = flag.String("kubeconfig", "", "Path to the kubeconfig file. If not specified, InClusterConfig will be used.")
+	flag.Parse()
+
+	if ( *kubeconfig != "" ) {
+		klog.Warningf("Using kubeconfig: %s", *kubeconfig)
+		cfg, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	} else {
+		cfg, err = rest.InClusterConfig()
+	}
+
 	if err != nil {
 		klog.Fatalf("Error building kubeconfig: %s", err.Error())
 	}
-
-	//trigger previous labels and configmaps
-	e := watcher.TriggerWatcher()
-	if e != nil {
-		fmt.Println("failed on triggering watcher for pre-existing labels", e, time.Now().UTC())
-	}
-	//purge unused configmaps and secrets
-	watcher.PurgeJob()
-
-	// set up signals so we handle the first shutdown signal gracefully
-	stopCh := signals.SetupSignalHandler()
 
 	clientSet, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		klog.Fatalf("Error building kubernetes clientset: %s", err.Error(), time.Now().UTC())
 	}
+
+	//trigger previous labels and configmaps
+	e := watcher.TriggerWatcher(clientSet)
+	if e != nil {
+		fmt.Println("failed on triggering watcher for pre-existing labels", e, time.Now().UTC())
+	}
+	//purge unused configmaps and secrets
+	watcher.PurgeJob(clientSet)
+
+	// set up signals so we handle the first shutdown signal gracefully
+	stopCh := signals.SetupSignalHandler()
 
 	configuratorClientSet, err := clientset.NewForConfig(cfg)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/gopaddle-io/configurator/issues/32

Allows the controller to receive KUBECONFIG file path
in the form of `--kubeconfig=/path/to/my/kube.config`.

That, in turn, allows developers to run the controller locally without
deploying it to the remote cluster, providing a better experience
debugging a local session in the IDE of their own choice.

Indirectly, it also provides single point where `rest.Config` is created
and reused throughout the code, eliminating the need to reload the
cluster configuration in various points.

Signed-off-by: Julio Morimoto <julio@morimoto.net.br>