### PR TITLE
Improve helm chart release cycle for develoeprs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 vendor/
 labelConfig/*
 main
-configurator
+/configurator

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,14 @@ ifndef DOCKER_IMAGE_TAG
   DOCKER_IMAGE_TAG=latest
 endif
 
+.PHONY: helm
+
 clean: clean-configurator
 build: build-configurator
 push: push-image
 deploy: deploy-configurator
-remove: remove-configurator
+remove: remove-configurator cleanup
+cleanup: cleanup-crds cleanup-ns
 
 clean-configurator: 
 	-rm -f configurator
@@ -27,11 +30,15 @@ deploy-configurator:
 
 remove-configurator:
 	-kubectl delete -f deploy/configurator-deployment.yaml
-	-kubectl delete -f deploy/crd-customConfigMap.yaml
-	-kubectl delete -f deploy/crd-customSecret.yaml
 	-kubectl delete -f deploy/configurator-clusterrolebinding.yaml
 	-kubectl delete -f deploy/configurator-clusterrole.yaml
 	-kubectl delete -f deploy/configurator-serviceaccount.yaml
+
+cleanup-crds:
+	-kubectl delete -f deploy/crd-customConfigMap.yaml
+	-kubectl delete -f deploy/crd-customSecret.yaml
+
+cleanup-ns:
 	-kubectl delete ns configurator
 
 build-configurator:
@@ -41,3 +48,7 @@ build-configurator:
 
 push-image:
 	-docker push ${DOCKER_IMAGE_REPO}:${DOCKER_IMAGE_TAG}
+
+helm:
+	cd helm && helm package ../helm-src/configurator
+	cd helm && helm repo index .

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In order to keep the deployments and statefulsets in sync with the ConfigMap and
 # Supported Versions
   - K8s 1.16+
 
-### Building and Deploying Configurator
+### Building and Deploying Configurator (developer)
 Build the source code and the docker image for Configurator. Push the image to registry and deploy configurator in the cluster.
 ```sh
 make clean build push deploy 
@@ -22,6 +22,10 @@ Remove the configurator deployment from cluster and delete local binary and dock
 ```sh
 make remove clean 
 ```
+
+### Helm chart for end-users
+
+It is important to note that `push` target is limited to project maintainers. For end-users, a helm chart is available. Please, follow the [instructions about using the Helm Chart](helm-src/README.md). At the moment, the helm chart provides limited values to be configured and will be improved overtime.
 
 ### Deploy Configurator using YAML files
 YAML files for deploying the latest version of Configurator is available under the deploy folder.You need to deploy the CRDs, the controller and the service/role binding.

--- a/helm-src/README.md
+++ b/helm-src/README.md
@@ -1,0 +1,92 @@
+# Helm Charts
+
+This directory contains the source code for the helm charts in this project, keeping the chart source code separate from the released packages.
+
+## Conflicts with a previous version installed with Yaml manifests
+
+Still at early stages of development, a Configurator version may have already been installed using provided Yaml manifests from the `./deploy` directory. That may cause conflicts with the helm chart, preventing a successfull installation on top of it. In order to avoid errors, uninstall the previous version before using the helm chart.
+
+> WARNING: This will also remove CRDs, which also removes all `CustomConfigMaps` and `CustomSecrets` previously created. Make sure to backup before proceeding.
+
+From the project's root directory, run:
+
+```
+make remove-configurator
+```
+
+## Install using the helm chart
+
+To use the helm chart, add the repository to your local helm installation.
+
+```
+helm repo add gopaddle_configurator https://gopaddle-io.github.io/configurator/helm
+helm repo up
+```
+
+Check if you can find the latest version locally.
+
+```
+helm search repo gopaddle_configurator
+```
+
+The output should be similar to the following:
+
+```
+NAME                              	CHART VERSION	APP VERSION	DESCRIPTION                                       
+gopaddle_configurator/configurator	0.1.0        	1.16.0     	Helm chart for installing configurator CRDs & C...
+```
+
+Install a new release running:
+
+```
+kubectl create namespace configurator
+helm install --namespace configurator configurator gopaddle_configurator/configurator
+```
+
+### Special notes about early releases
+
+At the moment, please take note to follow these steps carefully, creating the namespace `configurator` and including the `--namespace configurator` argument.
+
+### Upgrades
+
+To upgrade to a newer release when it becomes available, simply run:
+
+```
+helm repo up
+helm upgrade --install --namespace configurator configurator gopaddle_configurator/configurator
+```
+
+## Uninstall the helm release
+
+The release can be removed from the cluster running:
+
+```
+helm uninstall -n configurator configurator
+```
+
+CRDs, however will not be automatically removed. For a full cleanup, CRDs must be removed manually:
+
+> WARNING: Removing CRDs will also remove all `CustomConfigMaps` and `CustomSecrets` already created in the cluster. If you still need them, make sure to backup before proceeding.
+
+```
+make cleanup
+```
+
+## Development
+
+Chart development and testing can be done independently from the the indexed repository. Once a new version is ready for release, it needs be packaged and indexed.
+
+### Packaging a new version
+
+Remember to change `Chart.yaml` to update the values for:
+
+* `version` to reflect the new chart version.
+* `appVersion` to reflect the Configurator version.
+
+From the project's root directory, where the file `Makefile` is located, run:
+
+```
+make helm
+```
+
+A new package will be created in the `./helm` directory and the file `./helm/index.yaml` will be updated. Commit the changes and push.

--- a/helm-src/configurator/.helmignore
+++ b/helm-src/configurator/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-src/configurator/Chart.yaml
+++ b/helm-src/configurator/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: 1.16.0
+description: Helm chart for installing configurator CRDs & Custom Controller
+name: configurator
+type: application
+version: 0.1.0

--- a/helm-src/configurator/crds/crd-customConfigMap.yaml
+++ b/helm-src/configurator/crds/crd-customConfigMap.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: customconfigmaps.configurator.gopaddle.io
+spec:
+  group: configurator.gopaddle.io
+  version: v1alpha1
+  names:
+    kind: CustomConfigMap
+    plural: customconfigmaps
+    singular: customconfigmap
+    shortNames:
+    - ccm
+  scope: Namespaced

--- a/helm-src/configurator/crds/crd-customSecret.yaml
+++ b/helm-src/configurator/crds/crd-customSecret.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: customsecrets.configurator.gopaddle.io
+spec:
+  group: configurator.gopaddle.io
+  version: v1alpha1
+  names:
+    kind: CustomSecret
+    plural: customsecrets
+    singular: customsecret
+    shortNames:
+    - ccs
+  scope: Namespaced

--- a/helm-src/configurator/templates/configurator-clusterrole.yaml
+++ b/helm-src/configurator/templates/configurator-clusterrole.yaml
@@ -1,0 +1,107 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: configurator
+rules:
+  - apiGroups:
+    - configurator.gopaddle.io
+    resources:
+    - customsecrets
+    verbs:
+    - get
+    - list
+    - watch
+    - update
+    - create
+  - apiGroups:
+    - configurator.gopaddle.io
+    resources:
+    - customconfigmaps
+    verbs:
+    - get
+    - list
+    - watch
+    - update
+    - create
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - statefulsets
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - apps
+    - extensions
+    resources:
+    - replicasets
+    verbs:
+    - get
+    - list
+    - update
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - controllerrevisions
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    - events.k8s.io
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+

--- a/helm-src/configurator/templates/configurator-clusterrolebinding.yaml
+++ b/helm-src/configurator/templates/configurator-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: Configurator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: configurator
+subjects:
+- kind: ServiceAccount
+  name: configurator-controller
+  namespace: configurator

--- a/helm-src/configurator/templates/configurator-deployment.yaml
+++ b/helm-src/configurator/templates/configurator-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: configurator-controller
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: {{ .Values.replicas  }}
+  selector:
+    matchLabels:
+      configurator: configurator-controller
+  template:
+    metadata:
+      labels:
+        configurator: configurator-controller
+        app: configurator
+    spec:
+      containers:
+      - image: {{ .Values.image }}
+        imagePullPolicy: Always
+        name: configurator
+      serviceAccountName: configurator-controller

--- a/helm-src/configurator/templates/configurator-serviceaccount.yaml
+++ b/helm-src/configurator/templates/configurator-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: configurator-controller
+  namespace: {{ .Values.namespace }}

--- a/helm-src/configurator/values.yaml
+++ b/helm-src/configurator/values.yaml
@@ -1,0 +1,4 @@
+image: gopaddle/configurator:latest
+namespace: configurator
+replicaCount: 1
+replicas: 1


### PR DESCRIPTION
Create a `helm-src` directory to keep chart source code separate from the
released indexed packages.

Include `./helm-src/README.md` with detailed instructions on how to use the helm chart.

Update `./README.md` to include reference to helm chart.

Update `./Makefile` to include target to release helm charts and cleanup after a
uninstalling a helm release.